### PR TITLE
Minify plugin .js files and create source maps

### DIFF
--- a/src/PluginWebpackConfig.js
+++ b/src/PluginWebpackConfig.js
@@ -39,10 +39,20 @@ function PluginWebpackConfig(fqcn, _options, additionalConfig) {
         { test: /\.js(x)?$/, loader: 'babel-loader', exclude: /node_modules|\.node_cache/ },
       ],
     },
+    devtool: 'source-map',
     plugins: [
       new HtmlWebpackPlugin({ filename: `${getPluginFullName(fqcn)}.module.json`, template: moduleJsonTemplate }),
       new webpack.DllReferencePlugin({ manifest: VENDOR_MANIFEST, context: options.root_path }),
       new webpack.DllReferencePlugin({ manifest: VENDOR_MANIFEST, context: options.web_src_path }),
+      new webpack.optimize.UglifyJsPlugin({
+        minimize: true,
+        sourceMap: true,
+        compress: {
+          warnings: false,
+        },
+      }),
+      new webpack.optimize.DedupePlugin(),
+      new webpack.optimize.OccurenceOrderPlugin(),
     ],
     resolve: {
       root: [path.resolve(options.web_src_path, 'src')],

--- a/src/PluginWebpackConfig.js
+++ b/src/PluginWebpackConfig.js
@@ -50,6 +50,9 @@ function PluginWebpackConfig(fqcn, _options, additionalConfig) {
         compress: {
           warnings: false,
         },
+        mangle: {
+          except: ['$super', '$', 'exports', 'require'],
+        },
       }),
       new webpack.optimize.DedupePlugin(),
       new webpack.optimize.OccurenceOrderPlugin(),


### PR DESCRIPTION
This reduces the .js file size for the pipeline plugin by 53%. Others
should be in a similar range.

Also enable the DedupePlugin and OccurenceOrderPlugin plugin like we do
in the server webpack build.
